### PR TITLE
Add Bagforge bag addon integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It also features a loot tracker, showing you transmog looted by your fellow part
 Currently supported addons:
 - ArkInventory
 - Baganator
+- Bagforge
 - BetterBags
 - World Quest Tab
 - World Quests List

--- a/Settings.lua
+++ b/Settings.lua
@@ -410,6 +410,9 @@ function app:CreateSettings()
 		if C_AddOns.IsAddOnLoaded("Baganator") then
 			Baganator.API.RequestItemButtonsRefresh()
 		end
+		if C_AddOns.IsAddOnLoaded("Bagforge") and Bagforge.API then
+			Bagforge.API:RequestItemButtonsRefresh()
+		end
 	end
 
 	function app:UpdatePreviewItems()

--- a/TransmogLootHelper.toc
+++ b/TransmogLootHelper.toc
@@ -3,7 +3,7 @@
 ## Author: Slackluster
 ## Notes: Adds icons to your items to show their collection status
 ## IconTexture: Interface\AddOns\TransmogLootHelper\assets\icon.png
-## Version: v12.0.7-02
+## Version: @project-version@
 ## X-Curse-Project-ID: 1033752
 ## X-Wago-ID: EGPXOkG1
 

--- a/TransmogLootHelper.toc
+++ b/TransmogLootHelper.toc
@@ -3,7 +3,7 @@
 ## Author: Slackluster
 ## Notes: Adds icons to your items to show their collection status
 ## IconTexture: Interface\AddOns\TransmogLootHelper\assets\icon.png
-## Version: @project-version@
+## Version: v12.0.7-02
 ## X-Curse-Project-ID: 1033752
 ## X-Wago-ID: EGPXOkG1
 
@@ -42,6 +42,7 @@ integrations\ArkInventory.lua
 integrations\Baganator.lua
 integrations\BetterBags.lua
 integrations\OneWoW_Bags.lua
+integrations\Bagforge.lua
 integrations\WorldQuestTab.lua
 locales\enUS.lua
 locales\deDE.lua

--- a/integrations/Bagforge.lua
+++ b/integrations/Bagforge.lua
@@ -1,0 +1,36 @@
+local appName, app = ...
+
+app.Event:Register("ADDON_LOADED", function(addOnName, containsBindings)
+	if addOnName == appName then
+		EventUtil.ContinueOnAddOnLoaded("Bagforge", function()
+			local API = Bagforge and Bagforge.API
+			if not API or not API.RegisterItemButtonCallback then
+				return
+			end
+
+			local function UpdateItemButton(button, bagID, slotID)
+				if not button then
+					return
+				end
+				if not button.TLHOverlay then
+					button.TLHOverlay = CreateFrame("Frame", nil, button)
+					button.TLHOverlay:SetAllPoints(button)
+					button.TLHOverlay:SetFrameLevel(button:GetFrameLevel() + 1)
+				end
+
+				local itemLocation = ItemLocation:CreateFromBagAndSlot(bagID, slotID)
+				if C_Item.DoesItemExist(itemLocation) then
+					local itemLink = C_Item.GetItemLink(itemLocation)
+					local containerInfo = C_Container.GetContainerItemInfo(bagID, slotID)
+					if itemLink and containerInfo then
+						app:ApplyItemOverlay(button.TLHOverlay, itemLink, itemLocation, containerInfo, true)
+					end
+				else
+					button.TLHOverlay:Hide()
+				end
+			end
+
+			API:RegisterItemButtonCallback("TransmogLootHelper", UpdateItemButton)
+		end)
+	end
+end)

--- a/modules/ItemOverlay.lua
+++ b/modules/ItemOverlay.lua
@@ -1414,6 +1414,7 @@ function api:UpdateOverlay()
 				app:TradeskillOverlay()
 				app:AuctionHouseOverlay()
 				if C_AddOns.IsAddOnLoaded("Baganator") then Baganator.API.RequestItemButtonsRefresh() end
+				if C_AddOns.IsAddOnLoaded("Bagforge") and Bagforge.API then Bagforge.API:RequestItemButtonsRefresh() end
 
 				app.RefreshTimer = GetServerTime()
 			end


### PR DESCRIPTION
## Summary

- Adds `integrations/Bagforge.lua`, mirroring the existing OneWoW_Bags integration pattern.
- Registers TLH overlays on Bagforge item buttons via `Bagforge.API:RegisterItemButtonCallback`.
- Calls `Bagforge.API:RequestItemButtonsRefresh()` when overlay settings change (same as Baganator).
- Lists Bagforge in README supported addons.

## Bagforge API (upstream addon)

Bagforge exposes this plugin surface for third-party bag overlays:

```lua
Bagforge.API:RegisterItemButtonCallback("TransmogLootHelper", function(button, bagID, slotID, entry) ... end)
Bagforge.API:RequestItemButtonsRefresh()
```

Maintainer: happy to adjust if you prefer a different hook shape.

## Test plan

- [x] Enable TransmogLootHelper + Bagforge; open backpack — transmog/collection icons appear on eligible items.
- [x] Open bank (Bagforge bank view) — overlays appear on bank items.
- [x] Change TLH icon style in settings — Bagforge buttons refresh without `/reload`.
- [x] Toggle TLH overlay off — icons disappear from Bagforge buttons.
- [x] Verify no errors with only one of the two addons loaded.
